### PR TITLE
Upgrade middleware to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/International-Combat-Archery-Alliance/auth v0.3.1
 	github.com/International-Combat-Archery-Alliance/captcha v0.1.0
 	github.com/International-Combat-Archery-Alliance/email v0.6.0
-	github.com/International-Combat-Archery-Alliance/middleware v0.4.0
+	github.com/International-Combat-Archery-Alliance/middleware v0.5.0
 	github.com/International-Combat-Archery-Alliance/payments v0.8.1
 	github.com/International-Combat-Archery-Alliance/telemetry v0.2.0
 	github.com/Rhymond/go-money v1.0.15

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/International-Combat-Archery-Alliance/captcha v0.1.0 h1:QAXrGpm8XulV2
 github.com/International-Combat-Archery-Alliance/captcha v0.1.0/go.mod h1:a7DP91/hhCXZLiFdRdgNkz6+qpGwY6dflL9dBEqEN1M=
 github.com/International-Combat-Archery-Alliance/email v0.6.0 h1:ijGrU3sjciaNP+qzkFGPsUN9p6bWybrnxT7hEtqeC/Y=
 github.com/International-Combat-Archery-Alliance/email v0.6.0/go.mod h1:C8UpQfO+B59+wrJdCPPJdxjLjXLZiV7vqwXCEDfNRfs=
-github.com/International-Combat-Archery-Alliance/middleware v0.4.0 h1:Q5Hov3WzUcgYOX4FNzkQcO65jlPYpWDVjx16UBZOZpQ=
-github.com/International-Combat-Archery-Alliance/middleware v0.4.0/go.mod h1:W5agYaAIyixBuUHBzMHTFs0OYFYaeAum2PS4lSxh//U=
+github.com/International-Combat-Archery-Alliance/middleware v0.5.0 h1:zEfREiAW/Q5nvEf3ZAg2wFiaOV9IrjkTvCSNcwp+IR8=
+github.com/International-Combat-Archery-Alliance/middleware v0.5.0/go.mod h1:W5agYaAIyixBuUHBzMHTFs0OYFYaeAum2PS4lSxh//U=
 github.com/International-Combat-Archery-Alliance/payments v0.8.1 h1:ngmv9ERNatT5MScbKpSkJ3rZBHNrCtwBdTWMuKHWU+8=
 github.com/International-Combat-Archery-Alliance/payments v0.8.1/go.mod h1:q1SUHDzQYgswL5VsftqqOhE2YaqWIYdvmLMx3Tqc8Gw=
 github.com/International-Combat-Archery-Alliance/telemetry v0.2.0 h1:5NJOVZBkHvZahfJgpWaOv1xvYR56WbVPG5NLOoz9s6U=


### PR DESCRIPTION
Bumps the middleware dependency from v0.4.0 to v0.5.0.

No breaking changes. v0.5.0 adds client IP access logging support.